### PR TITLE
feat: kera-desktop fallback to gnome

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_NAME="${BASE_IMAGE_NAME:-base}"
+ARG BASE_IMAGE_NAME="${BASE_IMAGE_NAME:-silverblue}"
 ARG IMAGE_FLAVOR="${IMAGE_FLAVOR:-main}"
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-$BASE_IMAGE_NAME-$IMAGE_FLAVOR}"
 ARG BASE_IMAGE="ghcr.io/ublue-os/${SOURCE_IMAGE}"
@@ -17,8 +17,8 @@ RUN wget -qO /tmp/kera-desktop.tar.gz "https://gitlab.com/kerahq/releases/-/raw/
     mkdir -p /usr/share/kera-desktop-bin && \
     tar -xf /tmp/kera-desktop.tar.gz -C /usr/share/kera-desktop-bin && \
     /tmp/build.sh && \
+    echo -e '[daemon]\nDefaultSession=kera.desktop' >> /etc/gdm/custom.conf && \
     rm -rf /tmp/* /var/* && \
-    systemctl enable sddm && \
     ostree container commit && \
     mkdir -p /var/tmp && \
     chmod -R 1777 /var/tmp

--- a/packages.json
+++ b/packages.json
@@ -2,25 +2,7 @@
     "all": {
         "include": {
             "all": [
-                "cage",
-                "sddm",
-                "wireplumber",
-                "pipewire-gstreamer",
-                "pipewire-pulseaudio",
-                "pipewire-alsa",
-                "pipewire-jack-audio-connection-kit",
-                "pipewire-plugin-libcamera",
-                "pavucontrol",
-                "gnome-software",
-                "nm-connection-editor",
-                "NetworkManager-adsl",
-                "NetworkManager-bluetooth",
-                "NetworkManager-ppp",
-                "NetworkManager-wifi",
-                "NetworkManager-wwan",
-                "blueman",
-                "polkit-gnome",
-                "qt5-qtwayland"
+                "cage"
             ]
         },
         "exclude": {

--- a/usr/share/wayland-sessions/kera-desktop.desktop
+++ b/usr/share/wayland-sessions/kera-desktop.desktop
@@ -1,5 +1,0 @@
-[Desktop Entry]
-Name=Kera Desktop on Weston
-Comment=Kera Desktop Session On Weston
-Exec=/usr/bin/kera-session
-Type=Application

--- a/usr/share/wayland-sessions/kera.desktop
+++ b/usr/share/wayland-sessions/kera.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Kera Desktop
+Comment=Kera Desktop Session
+Exec=/usr/bin/kera-session
+Type=Application


### PR DESCRIPTION
This PR rebases the Kera desktop image to Silverblue as a way to provide a fallback desktop environment

<!--
- feat!: clean repo and add kera-session with proper build
- feat: gnome-desktop as fallback for kera desktop for now
-->
